### PR TITLE
Mattermost requires 8443 to be open (conflict with jitsi)

### DIFF
--- a/deploy/services/mattermost-install.sh
+++ b/deploy/services/mattermost-install.sh
@@ -28,6 +28,9 @@ sed -i "s/^DOMAIN=.*/DOMAIN=$DOMAIN_ARG/" .env
 # Pin to a stable release tag
 sed -i "s/^MATTERMOST_IMAGE_TAG=.*/MATTERMOST_IMAGE_TAG=release-10.5/" .env
 
+# Remap CALLS_PORT away from 8443 to avoid conflicts with Jitsi Meet
+sed -i "s/^CALLS_PORT=.*/CALLS_PORT=8445/" .env
+
 # Set postgres password if provided
 if [ -n "$POSTGRES_PASSWORD_ARG" ]; then
 	sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$POSTGRES_PASSWORD_ARG/" .env
@@ -58,4 +61,9 @@ echo ""
 echo "========================================"
 echo "Mattermost running at https://$DOMAIN_ARG (Caddy proxies host port 8065)"
 echo "========================================"
+echo ""
+echo "IMPORTANT: Mattermost Calls (voice/video) requires UDP port 8445 to be"
+echo "open on this server's firewall. If you are using ufw, run:"
+echo "  sudo ufw allow 8445/udp"
+echo "If you are using a cloud provider, open UDP port 8445 in your security group."
 echo "========================================"

--- a/frontend/app/(dashboard)/wizards/Mattermost.Install/page.tsx
+++ b/frontend/app/(dashboard)/wizards/Mattermost.Install/page.tsx
@@ -58,7 +58,8 @@ export default function MattermostWizardPage() {
               ⚠️ Action required: open UDP port 8445
             </p>
             <p className="text-sm text-amber-700">
-              Mattermost Calls (voice/video) streams audio and video directly over UDP. You must open port
+              Mattermost Calls (voice/video) streams audio and video directly over UDP.
+              You must open port
               {' '}
               <strong>8445/UDP</strong>
               {' '}

--- a/frontend/app/(dashboard)/wizards/Mattermost.Install/page.tsx
+++ b/frontend/app/(dashboard)/wizards/Mattermost.Install/page.tsx
@@ -53,6 +53,19 @@ export default function MattermostWizardPage() {
               <p className="text-gray-500">{domain}</p>
             </div>
           </div>
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
+            <p className="text-sm font-semibold text-amber-800 mb-1">
+              ⚠️ Action required: open UDP port 8445
+            </p>
+            <p className="text-sm text-amber-700">
+              Mattermost Calls (voice/video) streams audio and video directly over UDP. You must open port
+              {' '}
+              <strong>8445/UDP</strong>
+              {' '}
+              on your router or firewall (and in rathole/tunnel config if applicable).
+              Without this, Calls meetings will not connect.
+            </p>
+          </div>
           <p className="text-sm text-gray-500 mb-6">
             {'Caddy has been configured to proxy '}
             <strong>{domain}</strong>
@@ -93,6 +106,18 @@ export default function MattermostWizardPage() {
 
   return (
     <div className="max-w-4xl mx-auto p-8">
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4">
+        <p className="text-sm font-semibold text-amber-800 mb-1">⚠️ UDP port required for Calls</p>
+        <p className="text-sm text-amber-700">
+          Mattermost Calls (voice/video) streams directly over UDP
+          {' — this cannot go through an HTTP-only tunnel.'}
+          Make sure port
+          {' '}
+          <strong>8445/UDP</strong>
+          {' '}
+          is open on your router/firewall and forwarded to this server before proceeding.
+        </p>
+      </div>
       <MattermostWizard onComplete={handleWizardComplete} />
     </div>
   );


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves Issue #__

## Changes Made
<!-- List the main changes -->
- Changes required port from 8443 to 8445 due to conflicts with jitsi meet
- Banner prompting user to open port 8445 to UDP traffic

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
<img width="1854" height="985" alt="image" src="https://github.com/user-attachments/assets/300aaa2e-6bb9-4f4f-a525-7ed4bb4484b2" />



